### PR TITLE
Fix hyperxmp import

### DIFF
--- a/sistedes.cls
+++ b/sistedes.cls
@@ -51,7 +51,7 @@
 % Also \author and \title need to be overriden, so that they can be stored
 % before they are cleared, and as such can be further reused
 \RequirePackage[rgb,hyperref,usenames,dvipsnames,table]{xcolor}
-\RequirePackage[pdfa,pdfapart=1,pdfaconformance=b]{hyperref}
+\RequirePackage[pdfa]{hyperref}
 \RequirePackage{hyperxmp}
 \let\original@title\title
 \renewcommand{\title}[1]{%

--- a/sistedes.cls
+++ b/sistedes.cls
@@ -51,8 +51,8 @@
 % Also \author and \title need to be overriden, so that they can be stored
 % before they are cleared, and as such can be further reused
 \RequirePackage[rgb,hyperref,usenames,dvipsnames,table]{xcolor}
-\RequirePackage{hyperxmp}
 \RequirePackage[pdfa,pdfapart=1,pdfaconformance=b]{hyperref}
+\RequirePackage{hyperxmp}
 \let\original@title\title
 \renewcommand{\title}[1]{%
   \begingroup


### PR DESCRIPTION
Fix #6: requiere `hyperref` before `hyperxmp`.

But also now: **pdfapart** and **pdfaconformance** are undefined.

```
! Package keyval Error: pdfapart undefined.
...
! Package keyval Error: pdfaconformance undefined.
```

Theefore, to get something working needed to remove (comment them, so far).
[Docs](http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/hyperxmp/hyperxmp.pdf) refer they are _defaults values_ neither way:

> If the `pdfa` option was passed to hyperref but `\@pdfapart` is not set, set it to `1` and `\@pdfaconformance` to `B`.

So, removing them should be safe, so far.